### PR TITLE
Add value_to_string to the ArrayField to fix serialization to a string

### DIFF
--- a/djorm_pgarray/fields.py
+++ b/djorm_pgarray/fields.py
@@ -38,6 +38,9 @@ class ArrayField(models.Field):
     def to_python(self, value):
         return _cast_to_unicode(value)
 
+    def value_to_string(self, obj):
+        value = self._get_val_from_obj(obj)
+        return self.get_prep_value(value)
 
 # South support
 try:

--- a/testing/pg_array_fields/tests.py
+++ b/testing/pg_array_fields/tests.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from django.test import TestCase
+from django.core.serializers import serialize, deserialize
 
 from djorm_expressions.base import SqlExpression
 from .models import IntModel, TextModel, DoubleModel, MTextModel
@@ -49,3 +50,25 @@ class ArrayFieldTests(TestCase):
         obj = MTextModel.objects.create(data=[[u"1",u"2"],[u"3",u"ñ"]])
         obj = MTextModel.objects.get(pk=obj.pk)
         self.assertEqual(obj.data, [[u"1",u"2"],[u"3",u"ñ"]])
+
+    def test_value_to_string_serializes_correctly(self):
+        obj = MTextModel.objects.create(data=[[u"1",u"2"],[u"3",u"ñ"]])
+        obj_int = IntModel.objects.create(lista=[1,2,3])
+
+        serialized_obj = serialize('json', MTextModel.objects.filter(pk=obj.pk))
+        serialized_obj_int = serialize('json', IntModel.objects.filter(pk=obj_int.pk))
+
+        obj.delete()
+        obj_int.delete()
+
+        deserialized_obj = list(deserialize('json', serialized_obj))[0]
+        deserialized_obj_int = list(deserialize('json', serialized_obj_int))[0]
+
+        obj = deserialized_obj.object
+        obj_int = deserialized_obj_int.object
+        obj.save()
+        obj_int.save()
+
+
+        self.assertEqual(obj.data, [[u"1",u"2"],[u"3",u"ñ"]])
+        self.assertEqual(obj_int.lista, [1,2,3])


### PR DESCRIPTION
I wrote a test (included) around serializing and then deserializing an object with an arrayfield. WIthout the value_to_string implementation, there is an error when saving a deserialized object. This causes the test to fail. I noticed it in production when loading data from fixtures that were dumped to json.
