### PR TITLE
Added Basic Form Field for use with the arrays

### DIFF
--- a/djorm_pgarray/fields.py
+++ b/djorm_pgarray/fields.py
@@ -60,11 +60,19 @@ except ImportError:
     pass
 
 class ArrayFormField(forms.Field):
+    
+    def __init__(self, max_length=None, min_length=None, delim=None, *args, **kwargs):
+        if delim is not None:
+            self.delim = delim
+        else:
+            self.delim = ','
+        super(ArrayFormField, self).__init__(*args, **kwargs)
+
     def clean(self, value):
         try:
-            return value.split(',')
-        except :
+            return value.split(self.delim)
+        except:
             raise ValidationError
 
     def to_python(self, value):
-        return value.split(',')
+        return value.split(self.delim)


### PR DESCRIPTION
You can input in forms using a specific delimiter, the default is a comma ','

Example usage:

``` python
class TestArray(models.Model):
    text = ArrayField(dbtype='text')

class TestArrayForm(forms.ModelForm):
    class Meta:
        model = TestArray
    text = ArrayFormField(delim='-') # leave blank for default ','
```

Still working on rendering a form instance.
