### PR TITLE
Fix PostgreSQL requiring an explicit cast when using int or double precision arrays

### DIFF
--- a/djorm_pgarray/fields.py
+++ b/djorm_pgarray/fields.py
@@ -109,7 +109,7 @@ class ArrayFormField(forms.Field):
 
     def prepare_value(self, value):
         if value:
-            return self.delim.join('{0}'.format(v) for v in value)
+            return self.delim.join(str(v) for v in value)
         else:
             return super(ArrayFormField, self).prepare_value(value)
 

--- a/testing/pg_array_fields/tests.py
+++ b/testing/pg_array_fields/tests.py
@@ -55,6 +55,16 @@ class ArrayFieldTests(TestCase):
         obj = MTextModel.objects.get(pk=obj.pk)
         self.assertEqual(obj.data, [[u"1",u"2"],[u"3",u"ñ"]])
 
+    def test_correct_behavior_with_int_arrays(self):
+        obj = IntModel.objects.create(lista=[1,2,3])
+        obj = IntModel.objects.get(pk=obj.pk)
+        self.assertEqual(obj.lista, [1, 2, 3])
+
+    def test_correct_behavior_with_float_arrays(self):
+        obj = DoubleModel.objects.create(lista=[1.2,2.4,3])
+        obj = DoubleModel.objects.get(pk=obj.pk)
+        self.assertEqual(obj.lista, [1.2, 2.4, 3])
+
     def test_value_to_string_serializes_correctly(self):
         obj = MTextModel.objects.create(data=[[u"1",u"2"],[u"3",u"ñ"]])
         obj_int = IntModel.objects.create(lista=[1,2,3])


### PR DESCRIPTION
Values should be casted to the correct database type before sending them to the DB, without the cast, PostgreSQL will ask for explicit cast, because a str is used instead of an int or float.

The patch handles int, text and double precision arrays, some tests were added.
