### PR TITLE
Fix custom invalid error message (also fixes 1.6 compatibility).

### DIFF
--- a/djorm_pgarray/fields.py
+++ b/djorm_pgarray/fields.py
@@ -101,7 +101,7 @@ except ImportError:
 
 
 class ArrayFormField(forms.Field):
-    error_messages = {
+    default_error_messages = {
         'invalid': _('Enter a list of values, joined by commas.  E.g. "a,b,c".'),
     }
 

--- a/testing/pg_array_fields/forms.py
+++ b/testing/pg_array_fields/forms.py
@@ -3,6 +3,6 @@ from django.forms.models import ModelForm
 from .models import IntModel
 
 
-class IntArrayFrom(ModelForm):
+class IntArrayForm(ModelForm):
     class Meta:
         model = IntModel

--- a/testing/pg_array_fields/tests.py
+++ b/testing/pg_array_fields/tests.py
@@ -7,7 +7,7 @@ from django.core.serializers import serialize, deserialize
 from djorm_expressions.base import SqlExpression
 from djorm_pgarray.fields import ArrayFormField
 from .models import IntModel, TextModel, DoubleModel, MTextModel
-from .forms import IntArrayFrom
+from .forms import IntArrayForm
 
 
 class ArrayFieldTests(TestCase):
@@ -108,9 +108,9 @@ class ArrayFieldTests(TestCase):
 
 class ArrayFormFieldTests(TestCase):
     def test_regular_forms(self):
-        form = IntArrayFrom()
+        form = IntArrayForm()
         self.assertFalse(form.is_valid())
-        form = IntArrayFrom({'lista':u'[1,2]'})
+        form = IntArrayForm({'lista':u'[1,2]'})
         self.assertTrue(form.is_valid())
 
     def test_admin_forms(self):
@@ -123,3 +123,11 @@ class ArrayFormFieldTests(TestCase):
             form_instance.as_table()
         except TypeError:
             self.fail('HTML Rendering of the form caused a TypeError')
+
+    def test_invalid_error(self):
+        form = IntArrayForm({'lista':1})
+        self.assertFalse(form.is_valid())
+        self.assertEqual(
+            form.errors['lista'],
+            [u'Enter a list of values, joined by commas.  E.g. "a,b,c".']
+            )

--- a/testing/settings.py
+++ b/testing/settings.py
@@ -27,3 +27,5 @@ SECRET_KEY = 'di!n($kqa3)nd%ikad#kcjpkd^uw*h%*kj=*pm7$vbo6ir7h=l'
 INSTALLED_APPS = (
     'pg_array_fields',
 )
+
+TEST_RUNNER = 'django.test.simple.DjangoTestSuiteRunner'


### PR DESCRIPTION
The custom "invalid" error message for `ArrayFormField` was never being used, because it is supposed to be specified in a class attribute called `default_error_messages`, not `error_messages`. `self.error_messages` is set in `Field.__init__`.

This bug was sort of hidden in Django 1.5 and previous; the custom message was not used, but there was a default "invalid" message, and so no error occurred. In Django 1.6 `Field` no longer has an "invalid" error message by default, and so things blow up.

This pull request fixes it for all Django versions (and fixes a typo in the name of a testing form class, and adds a `TEST_RUNNER` setting so that the tests continue to work on Django 1.6 as they do now).
