### PR TITLE
Fix handling of blank form fields.

### DIFF
--- a/djorm_pgarray/fields.py
+++ b/djorm_pgarray/fields.py
@@ -115,6 +115,8 @@ class ArrayFormField(forms.Field):
         super(ArrayFormField, self).__init__(*args, **kwargs)
 
     def clean(self, value):
+        if not value:
+            return []
         # If Django already parsed value to list
         if isinstance(value, list):
             return value

--- a/testing/pg_array_fields/tests.py
+++ b/testing/pg_array_fields/tests.py
@@ -113,6 +113,11 @@ class ArrayFormFieldTests(TestCase):
         form = IntArrayFrom({'lista':u'[1,2]'})
         self.assertTrue(form.is_valid())
 
+    def test_empty_value(self):
+        form = IntArrayFrom({'lista':u''})
+        self.assertTrue(form.is_valid())
+        self.assertEqual(form.cleaned_data['lista'], [])
+
     def test_admin_forms(self):
         site = AdminSite()
         model_admin = ModelAdmin(IntModel, site)


### PR DESCRIPTION
If an `ArrayFormField` is submitted empty, it comes into the `clean` method as an empty string. Before this fix, it would be split on the delimiter, resulting in a length-one list containing the empty string. For an array field holding integers, this would cause an error in `_cast_to_type` when trying to cast an empty string to an integer.

Instead, an empty value should be cleaned to the empty list.
