### PR TITLE
Choices validation

### DIFF
--- a/djorm_pgarray/fields.py
+++ b/djorm_pgarray/fields.py
@@ -88,6 +88,11 @@ class ArrayField(models.Field):
         return json.dumps(self.get_prep_value(value),
                           cls=DjangoJSONEncoder)
 
+    def validate(self, value, model_instance):
+        for val in value:
+            super(ArrayField, self).validate(val, model_instance)
+
+
 # South support
 try:
     from south.modelsinspector import add_introspection_rules

--- a/testing/pg_array_fields/models.py
+++ b/testing/pg_array_fields/models.py
@@ -29,3 +29,7 @@ class MultiTypeModel(models.Model):
     smallints = ArrayField(dbtype="smallint")
     varchars = ArrayField(dbtype="varchar(30)")
     objects = ExpressionManager()
+
+
+class ChoicesModel(models.Model):
+    choices = ArrayField(dbtype='text', choices=[('A', 'A'), ('B', 'B')])

--- a/testing/pg_array_fields/tests.py
+++ b/testing/pg_array_fields/tests.py
@@ -6,7 +6,8 @@ from django.core.serializers import serialize, deserialize
 
 from djorm_expressions.base import SqlExpression
 
-from .models import IntModel, TextModel, DoubleModel, MTextModel, MultiTypeModel
+from .models import (
+    IntModel, TextModel, DoubleModel, MTextModel, MultiTypeModel, ChoicesModel)
 from .forms import IntArrayForm
 
 
@@ -115,6 +116,11 @@ class ArrayFieldTests(TestCase):
 
         self.assertEqual(obj.smallints, [1, 2, 3])
         self.assertEqual(obj.varchars, ['One', 'Two', 'Three'])
+
+    def test_choices_validation(self):
+        obj = ChoicesModel(choices=['A'])
+        obj.full_clean()
+        obj.save()
 
 
 class ArrayFormFieldTests(TestCase):


### PR DESCRIPTION
Adding this `validate` method to `ArrayField` allows one to set `choices` on an `ArrayField` and still have that model pass model validation.
