### PR TITLE
Allow user override of form field class.

### DIFF
--- a/djorm_pgarray/fields.py
+++ b/djorm_pgarray/fields.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-import sys
 import json
 
 from django import forms
@@ -66,7 +65,7 @@ class ArrayField(models.Field):
         super(ArrayField, self).__init__(*args, **kwargs)
 
     def formfield(self, **params):
-        params['form_class'] = ArrayFormField
+        params.setdefault('form_class', ArrayFormField)
         return super(ArrayField, self).formfield(**params)
 
     def db_type(self, connection):

--- a/testing/pg_array_fields/tests.py
+++ b/testing/pg_array_fields/tests.py
@@ -5,7 +5,7 @@ from django.test import TestCase
 from django.core.serializers import serialize, deserialize
 
 from djorm_expressions.base import SqlExpression
-from djorm_pgarray.fields import ArrayFormField
+from djorm_pgarray.fields import ArrayField
 
 from .models import IntModel, TextModel, DoubleModel, MTextModel, MultiTypeModel
 from .forms import IntArrayForm
@@ -106,6 +106,14 @@ class ArrayFieldTests(TestCase):
 
         self.assertEqual(obj.data, [[u"1",u"2"],[u"3",u"ñ"]])
         self.assertEqual(obj_int.lista, [1,2,3])
+
+    def test_can_override_formfield(self):
+        model_field = ArrayField()
+        class FakeFieldClass(object):
+            def __init__(self, *args, **kwargs):
+                pass
+        form_field = model_field.formfield(form_class=FakeFieldClass)
+        self.assertIsInstance(form_field, FakeFieldClass)
 
     def test_other_types_properly_casted(self):
         obj = MultiTypeModel.objects.create(


### PR DESCRIPTION
The `formfield()` method should use `setdefault` for setting `form_class` so that a user can supply a different `form_class` if desired, instead of enforcing that `ArrayFormField` is always used.
