### PR TITLE
Use TypedMultipleChoiceField for ArrayField with choices.

### DIFF
--- a/djorm_pgarray/fields.py
+++ b/djorm_pgarray/fields.py
@@ -74,6 +74,10 @@ class ArrayField(six.with_metaclass(models.SubfieldBase, models.Field)):
 
     def formfield(self, **params):
         params.setdefault('form_class', ArrayFormField)
+        params.setdefault('choices_form_class', forms.TypedMultipleChoiceField)
+        if self.choices:
+            params.setdefault('choices', self.get_choices(include_blank=False))
+            params.setdefault('coerce', self._type_cast)
         return super(ArrayField, self).formfield(**params)
 
     def get_db_prep_value(self, value, connection, prepared=False):

--- a/testing/pg_array_fields/tests.py
+++ b/testing/pg_array_fields/tests.py
@@ -6,6 +6,7 @@ import django
 from django.contrib.admin import AdminSite, ModelAdmin
 from django.core.serializers import serialize, deserialize
 from django.db import connection
+from django import forms
 from django.test import TestCase
 
 from djorm_pgarray.fields import ArrayField, ArrayFormField
@@ -170,6 +171,13 @@ class ArrayFieldTests(TestCase):
                 pass
         form_field = model_field.formfield(form_class=FakeFieldClass)
         self.assertIsInstance(form_field, FakeFieldClass)
+
+    def test_default_formfield_with_choices(self):
+        model_field = ArrayField(choices=[('a', 'a')], dbtype='text')
+        form_field = model_field.formfield()
+        self.assertIsInstance(form_field, forms.TypedMultipleChoiceField)
+        self.assertEqual(form_field.choices, [('a', 'a')])
+        self.assertEqual(form_field.coerce, str)
 
     def test_other_types_properly_casted(self):
         obj = MultiTypeModel.objects.create(


### PR DESCRIPTION
This pull request implements better default formfield support for `ArrayField` with `choices` set. The appropriate default form field for that situation is `TypedMultipleChoiceField` (rather than Django's default of `TypedChoiceField`), and it is inappropriate to add a blank choice (the equivalent for an array is simply to not select any choices). This pull request implements those two changes (such that they remain overridable by the user), and also sets the type-coercion function for the form field to match the `ArrayField` type-coercion function.
