### PR TITLE
Better support for null/blank=False

### DIFF
--- a/djorm_pgarray/fields.py
+++ b/djorm_pgarray/fields.py
@@ -6,6 +6,7 @@ import django
 from django import forms
 from django.core.exceptions import ValidationError
 from django.core.serializers.json import DjangoJSONEncoder
+from django.core import validators
 from django.db import models
 from django.utils import six
 from django.utils.encoding import force_text
@@ -104,6 +105,12 @@ class ArrayField(six.with_metaclass(models.SubfieldBase, models.Field)):
                           cls=DjangoJSONEncoder)
 
     def validate(self, value, model_instance):
+        if value is None and not self.null:
+            raise ValidationError(self.error_messages['null'])
+
+        if not self.blank and value in validators.EMPTY_VALUES:
+            raise ValidationError(self.error_messages['blank'])
+
         for val in value:
             super(ArrayField, self).validate(val, model_instance)
 


### PR DESCRIPTION
Since the default value of null is different here than in django by default, south needs to know it needs to keep track of it. That's the first commit.

The second commit mimic's the parent class's validation when null and/or blank have been manually set to false. This makes `model_instance.full_clean()` work correctly in this case.

More details on #27. Cheers.
