### PR TITLE
Fixed empty TextArrayFields always being marked as 'has_changed'

### DIFF
--- a/djorm_pgarray/fields.py
+++ b/djorm_pgarray/fields.py
@@ -244,6 +244,8 @@ class ArrayFormField(forms.Field):
         return super(ArrayFormField, self).prepare_value(value)
 
     def to_python(self, value):
+        if value is None or value == u"":
+            return []
         return value.split(self.delim)
 
 


### PR DESCRIPTION
I ran into a problem where I was using a `TextArrayField` and every time I saved the form (in the admin) with no value in the field, it was marking the field as changed even though it was remaining empty.

I tracked it down to `BaseForm.changed_data` in `django/forms/forms.py`. The `initial_value` of the `ArrayFormField` is `[]` but the `data_value` is `u''` which is triggering the `Field._has_changed`.

This was causing problems with `django-reversion` but probably is causing problems anywhere that `_has_changed` or `changed_data` is being used. This patch works for my case for `TextArrayField`, but further tests may be required for other `ArrayField` types or ones with dimensions > 1.
